### PR TITLE
Python 3 support

### DIFF
--- a/skidmarks.py
+++ b/skidmarks.py
@@ -146,12 +146,11 @@ def serial_test(sequence):
                      [1, 0, 1, 0, 1]
     :rtype: returns dict of {'chi': <chisquare value>, 'p': <p-value of said chisquare>}
 
-    >>> serial_test('101010101111000')
-    {'chi': 1.4285714285714286, 'p': 0.69885130769248427}
+    >>> sorted(serial_test('101010101111000').items())
+    [('chi', 1.4285714285714286), ('p', 0.69885130769248427)]
 
-    >>> serial_test('110000000000000111111111111')
-    {'chi': 18.615384615384617, 'p': 0.00032831021826061683}
-
+    >>> sorted(serial_test('110000000000000111111111111').items())
+    [('chi', 18.615384615384617), ('p', 0.00032831021826061683)]
     """
     #if isinstance(sequence, basestring): sequence = map(int, sequence)
     pairwise = izip(sequence[1:], sequence[:-1])
@@ -174,20 +173,18 @@ def gap_test(sequence, item=None):
     the gap test for runs. takes a sequence and option `item`
     :param item: is used to test for gaps.
     :rtype: dict of pvalue, chi-square and the `item`
-    >>> gap_test('100020001200000')
-    {'chi': 756406.99909855379, 'item': '1', 'p': 0.0}
+    >>> sorted(gap_test('100020001200000').items())
+    [('chi', 756406.99909855379), ('item', '1'), ('p', 0.0)]
 
-    >>> gap_test('101010111101000')
-    {'chi': 11.684911193438811, 'item': '1', 'p': 0.23166089118674466}
-
+    >>> sorted(gap_test('101010111101000').items())
+    [('chi', 11.684911193438811), ('item', '1'), ('p', 0.23166089118674466)]
 
     gap_test() will default to looking for gaps between the first value in
     the sequence (in this case '1') and each later occurrence. use the `item`
     kwarg to specify another value.
 
-        >>> gap_test('101010111101000', item='0')
-        {'chi': 11.028667632612191, 'item': '0', 'p': 0.27374903509732523}
-
+    >>> sorted(gap_test('101010111101000', item='0').items())
+    [('chi', 11.028667632612191), ('item', '0'), ('p', 0.27374903509732523)]
 
     """
 

--- a/skidmarks.py
+++ b/skidmarks.py
@@ -17,7 +17,12 @@ Any feedback or improvements are welcomed
 
 import math
 from scipy.stats import zprob, linregress, chisquare
-from itertools import groupby, izip
+from itertools import groupby
+# yoavram: Bug fix for Python 3 as suggested in https://github.com/nschloe/matplotlib2tikz/issues/20
+try:
+    from itertools import izip
+except ImportError:
+    izip = zip
 import numpy as np
 import collections
 

--- a/skidmarks.py
+++ b/skidmarks.py
@@ -173,8 +173,14 @@ def gap_test(sequence, item=None):
     the gap test for runs. takes a sequence and option `item`
     :param item: is used to test for gaps.
     :rtype: dict of pvalue, chi-square and the `item`
-    >>> sorted(gap_test('100020001200000').items())
-    [('chi', 756406.99909855379), ('item', '1'), ('p', 0.0)]
+
+    >>> result = gap_test('100020001200000')
+    >>> 756406 < result['chi'] < 756407
+    True
+    >>> result['item']
+    '1'
+    >>> np.allclose(result['p'], 0)
+    True
 
     >>> sorted(gap_test('101010111101000').items())
     [('chi', 11.684911193438811), ('item', '1'), ('p', 0.23166089118674466)]

--- a/skidmarks.py
+++ b/skidmarks.py
@@ -41,7 +41,7 @@ else:
     unicode = unicode
     bytes = str
     basestring = basestring
-    
+
 
 def wald_wolfowitz(sequence):
     """
@@ -115,7 +115,7 @@ def auto_correlation(sequence):
     """
     if isinstance(sequence, basestring):
         sequence = map(int, sequence)
-    seq = np.array(sequence, dtype=np.int)
+    seq = np.array(list(sequence), dtype=np.int)
     dseq = np.column_stack((seq[1:], seq[:-1]))
     slope, intercept, r, ttp, see = linregress(seq[1:], seq[:-1])
     cc = np.corrcoef(dseq, rowvar=0)[0][1]

--- a/skidmarks.py
+++ b/skidmarks.py
@@ -26,6 +26,23 @@ except ImportError:
 import numpy as np
 import collections
 
+# yoavram: fix string import stuff in python 3, see https://github.com/oxplot/fysom/issues/1
+try:
+    unicode = unicode
+except NameError:
+    # 'unicode' is undefined, must be Python 3
+    str = str
+    unicode = str
+    bytes = bytes
+    basestring = (str,bytes)
+else:
+    # 'unicode' exists, must be Python 2
+    str = str
+    unicode = unicode
+    bytes = str
+    basestring = basestring
+    
+
 def wald_wolfowitz(sequence):
     """
     implements the wald-wolfowitz runs test:

--- a/skidmarks.py
+++ b/skidmarks.py
@@ -92,7 +92,6 @@ def auto_correlation(sequence):
     >>> result = auto_correlation('00000001111111111100000000')
     >>> result['p'] < 0.05
     True
-
     >>> result['auto_correlation']
     0.83766233766233755
 
@@ -142,7 +141,7 @@ def serial_test(sequence):
     d = collections.defaultdict(int)
     for k in pairwise: d[k] += 1
     # order doesnt matter because the expected are all the same.
-    obs = np.array(d.values())
+    obs = np.array(list(d.values()))
     exp = np.ones_like(obs) * obs.mean()
 
     chi, pval =  chisquare(obs, exp)


### PR DESCRIPTION
Fix imports and tests so that they work both in python 3 and 2.
I didn't actually use the module, just made it support Python 3 for a student that wanted to use it but got import errors.
The fixes in #1 are included here.
